### PR TITLE
Updating NodeJS snippet to create an exception telemetry item

### DIFF
--- a/articles/azure-monitor/app/opentelemetry-add-modify.md
+++ b/articles/azure-monitor/app/opentelemetry-add-modify.md
@@ -1230,7 +1230,7 @@ span.recordException(e);
 ```javascript
 // Import the Azure Monitor OpenTelemetry plugin and OpenTelemetry API
 const { useAzureMonitor } = require("@azure/monitor-opentelemetry");
-const { trace } = require("@opentelemetry/api");
+const { trace, SpanKind } = require("@opentelemetry/api");
 
 // Enable Azure Monitor integration
 useAzureMonitor();
@@ -1239,7 +1239,9 @@ useAzureMonitor();
 const tracer = trace.getTracer("testTracer");
 
 // Start a span with the name "hello"
-let span = tracer.startSpan("hello");
+let span = tracer.startSpan("hello", {
+    kind: SpanKind.SERVER
+});
 
 // Try to throw an error
 try{


### PR DESCRIPTION
The current code snippet does not generate an actual exception telemetry item inside App Insights. The span kind needs to be set to server.

There is an example inside the PG's own sample app below:

![image](https://github.com/user-attachments/assets/b022722a-ec79-40a4-9d40-e3091efa5870)

https://github.com/Azure-Samples/azure-monitor-opentelemetry-node.js/blob/main/src/server.ts