### PR TITLE
Updated private link security docs for Platform Metrics support

### DIFF
--- a/articles/azure-monitor/logs/private-link-configure.md
+++ b/articles/azure-monitor/logs/private-link-configure.md
@@ -35,15 +35,24 @@ In this section, we review the step-by-step process of setting up a private link
 
 ### Connect Azure Monitor resources
 
+#### Connect Individual Azure Monitor resources
 Connect Azure Monitor resources like Log Analytics workspaces, Application Insights components, and [data collection endpoints](../essentials/data-collection-endpoint-overview.md)) to your Azure Monitor Private Link Scope (AMPLS).
 
 1. In your AMPLS, select **Azure Monitor Resources** in the menu on the left. Select **Add**.
-1. Add the workspace or component. Selecting **Add** opens a dialog where you can select Azure Monitor resources. You can browse through your subscriptions and resource groups. You can also enter their names to filter down to them. Select the workspace or component and select **Apply** to add them to your scope.
+1. Add the workspace, component, or data collection endpoint. Selecting **Add** opens a dialog where you can select Azure Monitor resources. You can browse through your subscriptions and resource groups. You can also enter their names to filter down to them. Select the resource you'd like to add and select **Apply** to add them to your scope.
 
-    :::image type="content" source="./media/private-link-security/ampls-select-2.png" lightbox="./media/private-link-security/ampls-select-2.png" alt-text="Screenshot that shows selecting a scope.":::
+    :::image type="content" source="./media/private-link-security/ampls-select-resource.png" lightbox="./media/private-link-security/ampls-select-resource.png" alt-text="Screenshot that shows Select a Scope.":::
 
 > [!NOTE]
 > Deleting Azure Monitor resources requires that you first disconnect them from any AMPLS objects they're connected to. It's not possible to delete resources connected to an AMPLS.
+
+#### Connect Platform Metrics subscriptions
+In addition to individual resources, you can also connect Platform Metrics by scoping an entire subscription to your AMPLS. Scoping a subscription for Platform Metrics will not affect individual Azure Monitor resources in that subscription.
+
+1. In your AMPLS, select **Platform Metrics Subscriptions** in the menu on the left. Select **Add**.
+2. From the **Add Subscription** panel, select a subscription you would like to connect to your AMPLS. You can enter their names to filter down to the subscription you are looking for. When you've selected the correct subscription, select **Apply** to add them to your scope
+
+    :::image type="content" source="./media/private-link-security/ampls-select-metrics-subscription.png" lightbox="./media/private-link-security/ampls-select-resource.png" alt-text="Screenshot that shows selecting a platform metrics subscription.":::
 
 ### Connect to a private endpoint
 

--- a/articles/azure-monitor/logs/private-link-security.md
+++ b/articles/azure-monitor/logs/private-link-security.md
@@ -8,7 +8,7 @@ ms.date: 07/25/2023
 
 # Use Azure Private Link to connect networks to Azure Monitor
 
-With [Azure Private Link](/azure/private-link/private-link-overview), you can securely link Azure platform as a service (PaaS) resources to your virtual network by using private endpoints. Azure Monitor is a constellation of different interconnected services that work together to monitor your workloads. An Azure Monitor private link connects a private endpoint to a set of Azure Monitor resources to define the boundaries of your monitoring network. That set is called an Azure Monitor Private Link Scope (AMPLS).
+With [Azure Private Link](../../private-link/private-link-overview.md), you can securely link Azure platform as a service (PaaS) resources to your virtual network by using private endpoints. Azure Monitor is a constellation of different interconnected services that work together to monitor your workloads. An Azure Monitor private link connects a private endpoint to a set of Azure Monitor resources to define the boundaries of your monitoring network. That set is called an Azure Monitor Private Link Scope (AMPLS).
 
 > [!NOTE]
 > Azure Monitor private links are structured differently from private links to other services you might use. Instead of creating multiple private links, one for each resource the virtual network connects to, Azure Monitor uses a single private link connection, from the virtual network to an AMPLS. AMPLS is the set of all Azure Monitor resources to which a virtual network connects through a private link.
@@ -23,7 +23,7 @@ With Private Link you can:
 - Securely connect your private on-premises network to Azure Monitor by using Azure ExpressRoute and Private Link.
 - Keep all traffic inside the Azure backbone network.
 
-For more information, see [Key benefits of Private Link](/azure/private-link/private-link-overview#key-benefits).
+For more information, see [Key benefits of Private Link](../../private-link/private-link-overview.md#key-benefits).
 
 ## How it works: Main principles
 An Azure Monitor private link connects a private endpoint to a set of Azure Monitor resources made up of Log Analytics workspaces and Application Insights resources. That set is called an Azure Monitor Private Link Scope.

--- a/articles/azure-monitor/logs/private-link-security.md
+++ b/articles/azure-monitor/logs/private-link-security.md
@@ -58,6 +58,11 @@ When you configure Private Link even for a single resource, traffic to the follo
 >
 > Private Link settings for Managed Prometheus and ingesting data into your Azure Monitor workspace are configured on the Data Collection Endpoints for the referenced resource. Settings for querying your Azure Monitor workspace over Private Link are made directly on the Azure Monitor workspace and are not handled via AMPLS.
 
+### Kinds of scoped resources
+AMPLS makes a distinction between two kinds of resources, which must be specified when adding resources to a private link scope:
+- `Resource` kind is the label applied to all individual resources that can be scoped to AMPLS. This kind applies to application insights, log analytics workspaces, and data collection endpoints
+- `PlatformMetrics` kind is the label that applies to platform metrics within a subscription. Unlike resource kind, instead of scoping a single resource, an entire subscription and region is added to the AMPLS for platform metrics support. Scoping a subscription with kind `PlatformMetric` will not affect the application insights, log analytics workspaces, or data collection endpoints within that subscription.
+
 ### Resource-specific endpoints
 Log Analytics endpoints are workspace specific, except for the query endpoint discussed earlier. As a result, adding a specific Log Analytics workspace to the AMPLS will send ingestion requests to this workspace over the private link. Ingestion to other workspaces will continue to use the public endpoints.
 

--- a/articles/azure-monitor/logs/private-link-security.md
+++ b/articles/azure-monitor/logs/private-link-security.md
@@ -8,7 +8,7 @@ ms.date: 07/25/2023
 
 # Use Azure Private Link to connect networks to Azure Monitor
 
-With [Azure Private Link](../../private-link/private-link-overview.md), you can securely link Azure platform as a service (PaaS) resources to your virtual network by using private endpoints. Azure Monitor is a constellation of different interconnected services that work together to monitor your workloads. An Azure Monitor private link connects a private endpoint to a set of Azure Monitor resources to define the boundaries of your monitoring network. That set is called an Azure Monitor Private Link Scope (AMPLS).
+With [Azure Private Link](/azure/private-link/private-link-overview), you can securely link Azure platform as a service (PaaS) resources to your virtual network by using private endpoints. Azure Monitor is a constellation of different interconnected services that work together to monitor your workloads. An Azure Monitor private link connects a private endpoint to a set of Azure Monitor resources to define the boundaries of your monitoring network. That set is called an Azure Monitor Private Link Scope (AMPLS).
 
 > [!NOTE]
 > Azure Monitor private links are structured differently from private links to other services you might use. Instead of creating multiple private links, one for each resource the virtual network connects to, Azure Monitor uses a single private link connection, from the virtual network to an AMPLS. AMPLS is the set of all Azure Monitor resources to which a virtual network connects through a private link.
@@ -23,7 +23,7 @@ With Private Link you can:
 - Securely connect your private on-premises network to Azure Monitor by using Azure ExpressRoute and Private Link.
 - Keep all traffic inside the Azure backbone network.
 
-For more information, see [Key benefits of Private Link](../../private-link/private-link-overview.md#key-benefits).
+For more information, see [Key benefits of Private Link](/azure/private-link/private-link-overview#key-benefits).
 
 ## How it works: Main principles
 An Azure Monitor private link connects a private endpoint to a set of Azure Monitor resources made up of Log Analytics workspaces and Application Insights resources. That set is called an Azure Monitor Private Link Scope.


### PR DESCRIPTION
Azure Monitor Private Link Scopes (AMPLS) is adding support for platform metrics, which includes a new API version as well as a new UX blade and a new kind of scoped resource. These doc changes provide information about the latest API version, how to use the new UX, and how to scope resources with the latest updates.