### PR TITLE
Update create-custom-table.md

### DIFF
--- a/articles/azure-monitor/logs/create-custom-table.md
+++ b/articles/azure-monitor/logs/create-custom-table.md
@@ -72,7 +72,7 @@ To create a custom table using the Azure portal:
 
 1. Specify a name and, optionally, a description for the table. You don't need to add the *_CL* suffix to the custom table's name - this is added automatically to the name you specify in the portal. 
 
-1. Select an existing data collection rule from the **Data collection rule** dropdown, or select **Create a new data collection rule** and specify the **Subscription**, **Resource group**, and **Name** for the new data collection rule. 
+1. Select an existing data collection rule with platform type set to *All* from the **Data collection rule** dropdown, or select **Create a new data collection rule** and specify the **Subscription**, **Resource group**, and **Name** for the new data collection rule. 
 
     :::image type="content" source="media/tutorial-logs-ingestion-portal/new-data-collection-rule.png" lightbox="media/tutorial-logs-ingestion-portal/new-data-collection-rule.png" alt-text="Screenshot showing new data collection rule.":::
 


### PR DESCRIPTION
Specify DCR's kind must be All (not Linux/Windows) when creating a new DCR-based custom table in Azure Portal. DCR with other platform types are removed from the dropdown menu. However, this behavior is not documented.

Reproduction: If I create 3 DCRs with identical setup but different Platform types, then only the one with Platform type _All_ is shown when creating a custom table.

![Screenshot 2024-10-18 110000](https://github.com/user-attachments/assets/4f51bc42-6457-4603-8c75-06d3fe152575)

![Screenshot 2024-10-18 110242](https://github.com/user-attachments/assets/607105c8-1ee0-44b4-8e12-017c394a874e)

Link to Article: [Add or delete tables and columns in Azure Monitor Logs - Azure Monitor | Microsoft Learn](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/create-custom-table?tabs=azure-portal-1%2Cazure-portal-2%2Cazure-portal-3#create-a-custom-table)
Link to File: [articles/azure-monitor/logs/create-custom-table.md#create-a-custom-table](https://github.com/MicrosoftDocs/azure-monitor-docs/blob/main/articles/azure-monitor/logs/create-custom-table.md#create-a-custom-table)