### PR TITLE
Update data-collection-windows-events.md

### DIFF
--- a/articles/azure-monitor/agents/data-collection-windows-events.md
+++ b/articles/azure-monitor/agents/data-collection-windows-events.md
@@ -43,6 +43,10 @@ XPath entries are written in the form `LogName!XPathQuery`. For example, you mig
 
 [!INCLUDE [azure-monitor-cost-optimization](../../../includes/azure-monitor-cost-optimization.md)]
 
+> [!NOTE]
+> AMA uses the system API EvtSubscribe [EvtSubscribe](/windows/win32/api/winevt/nf-winevt-evtsubscribe) to subscribe to Windows Event Logs. Windows OS does not allow subscribing to Windows Event Logs of type Analytic/Debug channels. You cannot subscribe to an Analytic or Debug channel then you cannot collect or export data from those channels to be ingested in Log Analytics.
+
+
 ### Extract XPath queries from Windows Event Viewer
 
 In Windows, you can use Event Viewer to extract XPath queries as shown in the following screenshots.

--- a/articles/azure-monitor/agents/data-collection-windows-events.md
+++ b/articles/azure-monitor/agents/data-collection-windows-events.md
@@ -44,7 +44,7 @@ XPath entries are written in the form `LogName!XPathQuery`. For example, you mig
 [!INCLUDE [azure-monitor-cost-optimization](../../../includes/azure-monitor-cost-optimization.md)]
 
 > [!NOTE]
-> AMA uses the system API EvtSubscribe [EvtSubscribe](/windows/win32/api/winevt/nf-winevt-evtsubscribe) to subscribe to Windows Event Logs. Windows OS does not allow subscribing to Windows Event Logs of type Analytic/Debug channels. You cannot subscribe to an Analytic or Debug channel then you cannot collect or export data from those channels to be ingested in Log Analytics.
+> AMA uses the system API [EvtSubscribe](/windows/win32/api/winevt/nf-winevt-evtsubscribe) to subscribe to Windows Event Logs. Windows OS does not allow subscribing to Windows Event Logs of type Analytic/Debug channels. You cannot subscribe to an Analytic or Debug channel then you cannot collect or export data from those channels to be ingested in Log Analytics.
 
 
 ### Extract XPath queries from Windows Event Viewer


### PR DESCRIPTION
We found cases where customers are unable to collect Windows Event Logs by using Azure Monitor Agent (AMA) through XPath with error "15009 The events for a direct channel go directly to a log file and cannot be subscribed to. Cannot subscribe to the following events" in logs collected by troubleshooter script. 

As per ICM 562334094. This is by design as Windows OS does not allow subscribing to windows event logs of type analytic/debug channels.

AMA uses the system API EvtSubscribe to subscribe to Windows Event Logs. This fails with the following errors from Windows OS:

https://learn.microsoft.com/en-us/windows/win32/api/winevt/nf-winevt-evtsubscribe  https://learn.microsoft.com/en-us/windows/win32/wes/windows-event-log-error-constants