### PR TITLE
Clarify When Span-based Exception Events are Exported to App Insights

### DIFF
--- a/articles/azure-monitor/app/opentelemetry-add-modify.md
+++ b/articles/azure-monitor/app/opentelemetry-add-modify.md
@@ -1273,7 +1273,7 @@ span.recordException(e);
 #### [Node.js](#tab/nodejs)
 
 The Node.js SDK will only export these manually recorded span-based exceptions to Application Insights as exceptions if they are recorded on the children of
-remote spans, or if the exception is recorded on a top level span.
+remote, internal spans, or if the exception is recorded on a top level span.
 
 ```javascript
 // Import the Azure Monitor OpenTelemetry plugin and OpenTelemetry API

--- a/articles/azure-monitor/app/opentelemetry-add-modify.md
+++ b/articles/azure-monitor/app/opentelemetry-add-modify.md
@@ -1272,6 +1272,9 @@ span.recordException(e);
 
 #### [Node.js](#tab/nodejs)
 
+The Node.js SDK will only export these manually recorded span-based exceptions to Application Insights as exceptions if they are recorded on the children of
+remote spans, or if the exception is recorded on a top level span.
+
 ```javascript
 // Import the Azure Monitor OpenTelemetry plugin and OpenTelemetry API
 const { useAzureMonitor } = require("@azure/monitor-opentelemetry");
@@ -1287,7 +1290,7 @@ const tracer = trace.getTracer("testTracer");
 let span = tracer.startSpan("hello");
 
 // Try to throw an error
-try{
+try {
     throw new Error("Test Error");
 }
 


### PR DESCRIPTION
We have specific logic that determines when span-based exception events are exported to Application Insights. We should expose this information to prevent customer confusion.