### PR TITLE
Update kubernetes-monitoring-firewall.md

### DIFF
--- a/articles/azure-monitor/containers/kubernetes-monitoring-firewall.md
+++ b/articles/azure-monitor/containers/kubernetes-monitoring-firewall.md
@@ -29,7 +29,7 @@ The following table lists the proxy and firewall configuration information requi
 > If you use private links, you must **only** add the [private data collection endpoints (DCEs)](../essentials/data-collection-endpoint-overview.md#components-of-a-dce). The containerized agent does not use the non-private endpoints listed above when using private links/data collection endpoints.
 
 > [!NOTE]
-> When using AMA with AMPLS, all of your Data Collection Rules must use Data Collection Endpoints. Those DCE's must be added to the AMPLS configuration using [private link](../logs/private-link-configure.md#connect-resources-to-the-ampls)
+> When using AMA with AMPLS, all of your Data Collection Rules must use Data Collection Endpoints. Those DCEs must be added to the AMPLS configuration using [private link](../logs/private-link-configure.md#connect-resources-to-the-ampls)
 
 ## Microsoft Azure operated by 21Vianet cloud
 

--- a/articles/azure-monitor/containers/kubernetes-monitoring-firewall.md
+++ b/articles/azure-monitor/containers/kubernetes-monitoring-firewall.md
@@ -24,6 +24,13 @@ The following table lists the proxy and firewall configuration information requi
 | `*.metrics.ingest.monitor.azure.com` | Azure monitor managed service for Prometheus - metrics ingestion endpoint (DCE) | 443 |
 | `<cluster-region-name>.handler.control.monitor.azure.com` | Fetch data collection rules for specific cluster | 443 |
 
+
+>[!NOTE]
+> If you use private links, you must **only** add the [private data collection endpoints (DCEs)](../essentials/data-collection-endpoint-overview.md#components-of-a-dce). The containerized agent does not use the non-private endpoints listed above when using private links/data collection endpoints.
+
+> [!NOTE]
+> When using AMA with AMPLS, all of your Data Collection Rules must use Data Collection Endpoints. Those DCE's must be added to the AMPLS configuration using [private link](../logs/private-link-configure.md#connect-resources-to-the-ampls)
+
 ## Microsoft Azure operated by 21Vianet cloud
 
 | Endpoint| Purpose | Port |


### PR DESCRIPTION
Found scenarios where users are not adding DCE firewall network rules when they are using AMPLS or Private link to allow data flow to Log Analytics or Azure Monitor Workspace (Prometheus). 

This is causing the following mdsd.error refreshing configuration "Data collection endpoint must be used to access configuration over private link. ErrorCode: -2146172665." However, our public documentation only mentions it and the command below when configuring private link. https://learn.microsoft.com/en-us/azure/azure-monitor/containers/kubernetes-monitoring-private-link#container-insights-log-analytics-workspace