### PR TITLE
azure-monitor: simplify relabel_configs examples

### DIFF
--- a/articles/azure-monitor/containers/prometheus-metrics-multiple-workspaces.md
+++ b/articles/azure-monitor/containers/prometheus-metrics-multiple-workspaces.md
@@ -180,13 +180,12 @@ Then configure which metrics are routed to which workspace, by adding an extra p
 
 ```yaml
 relabel_configs:
-- source_labels: [__address__]
-  target_label: microsoft_metrics_account
+- target_label: microsoft_metrics_account
   action: replace
   replacement: "MonitoringAccountLabel2"
 ```
 
-The source label is `__address__` because this label will always exist so this relabel config will always be applied. The target label will always be `microsoft_metrics_account` and its value should be replaced with the corresponding label value for the workspace.
+The target label will always be `microsoft_metrics_account` and its value should be replaced with the corresponding label value for the workspace.
 
 
 
@@ -222,8 +221,7 @@ scrape_configs:
     - source_labels: [__meta_kubernetes_pod_label_app]
       action: keep
       regex: "prometheus-reference-app-1"
-    - source_labels: [__address__]
-      target_label: microsoft_metrics_account
+    - target_label: microsoft_metrics_account
       action: replace
       replacement: "MonitoringAccountLabel1"
 - job_name: prometheus_ref_app_2
@@ -233,8 +231,7 @@ scrape_configs:
     - source_labels: [__meta_kubernetes_pod_label_app]
       action: keep
       regex: "prometheus-reference-app-2"
-    - source_labels: [__address__]
-      target_label: microsoft_metrics_account
+    - target_label: microsoft_metrics_account
       action: replace
       replacement: "MonitoringAccountLabel2"
 - job_name: prometheus_ref_app_3
@@ -244,8 +241,7 @@ scrape_configs:
     - source_labels: [__meta_kubernetes_pod_label_app]
       action: keep
       regex: "prometheus-reference-app-3"
-    - source_labels: [__address__]
-      target_label: microsoft_metrics_account
+    - target_label: microsoft_metrics_account
       action: replace
       replacement: "MonitoringAccountLabel3"
 ```


### PR DESCRIPTION
The intent of the `relabl_configs` examples in this document is to apply a new label to all metrics. The `source_labels` field is not needed, as the re-labeling does not use the values from `__address__`, and specifying `source_labels` is not necessary to select all metrics for re-labeling. We can simply omit this from the suggested configuration.