### PR TITLE
fix: Fix links to Log Analytics built-in roles

### DIFF
--- a/articles/azure-monitor/logs/manage-access.md
+++ b/articles/azure-monitor/logs/manage-access.md
@@ -248,13 +248,13 @@ In addition to using the built-in roles for a Log Analytics workspace, you can c
 **Example 1: Grant a user permission to read log data from their resources.**
 
 - Configure the workspace access control mode to *use workspace or resource permissions*.
-- Grant users `*/read` or `Microsoft.Insights/logs/*/read` permissions to their resources. If they're already assigned the [Log Analytics Reader](/azure/role-based-access-control/built-in-roles#reader) role on the workspace, it's sufficient.
+- Grant users `*/read` or `Microsoft.Insights/logs/*/read` permissions to their resources. If they're already assigned the [Log Analytics Reader](/azure/role-based-access-control/built-in-roles/analytics#log-analytics-reader) role on the workspace, it's sufficient.
 
 
 **Example 2: Grant a user permission to read log data from their resources and run a search job.**
 
 - Configure the workspace access control mode to *use workspace or resource permissions*.
-- Grant users `*/read` or `Microsoft.Insights/logs/*/read` permissions to their resources. If they're already assigned the [Log Analytics Reader](/azure/role-based-access-control/built-in-roles#reader) role on the workspace, it's sufficient.
+- Grant users `*/read` or `Microsoft.Insights/logs/*/read` permissions to their resources. If they're already assigned the [Log Analytics Reader](/azure/role-based-access-control/built-in-roles/analytics#log-analytics-reader) role on the workspace, it's sufficient.
 - Grant users the following permissions on the workspace:
   - `Microsoft.OperationalInsights/workspaces/tables/write`: Required to be able to create the search results table (_SRCH).
   - `Microsoft.OperationalInsights/workspaces/searchJobs/write`: Required to allow executing the search job operation. 
@@ -264,7 +264,7 @@ In addition to using the built-in roles for a Log Analytics workspace, you can c
 
 - Configure the workspace access control mode to *use workspace or resource permissions*.
 - Grant users the following permissions on the workspace: `Microsoft.OperationalInsights/workspaces/read` and `Microsoft.OperationalInsights/workspaces/sharedKeys/action`. With these permissions, users can't perform any workspace-level queries. They can only enumerate the workspace and use it as a destination for diagnostic settings or agent configuration.
-- Grant users the following permissions to their resources: `Microsoft.Insights/logs/*/read` and `Microsoft.Insights/diagnosticSettings/write`. If they're already assigned the [Log Analytics Contributor](/azure/role-based-access-control/built-in-roles#contributor) role, assigned the Reader role, or granted `*/read` permissions on this resource, it's sufficient.
+- Grant users the following permissions to their resources: `Microsoft.Insights/logs/*/read` and `Microsoft.Insights/diagnosticSettings/write`. If they're already assigned the [Log Analytics Contributor](/azure/role-based-access-control/built-in-roles/analytics#log-analytics-contributor) role, assigned the Reader role, or granted `*/read` permissions on this resource, it's sufficient.
 
 **Example 4: Grant a user permission to read log data from their resources, but not to send logs to the Log Analytics workspace or read security events.**
 
@@ -289,7 +289,7 @@ In addition to using the built-in roles for a Log Analytics workspace, you can c
 **Example 6: Restrict a user from restoring data from long-term retention.**
 
 - Configure the workspace access control mode to *use workspace or resource permissions*.
-- Assign the user to the [Log Analytics Contributor](/azure/role-based-access-control/built-in-roles#contributor) role.
+- Assign the user to the [Log Analytics Contributor](/azure/role-based-access-control/built-in-roles/analytics#log-analytics-contributor) role.
 - Add the following NonAction to block users from restoring data from long-term retention: `Microsoft.OperationalInsights/workspaces/restoreLogs/write`
 
 


### PR DESCRIPTION
The links currently go to the incorrect privileged roles