### PR TITLE
Update vminsights-dependency-agent.md

### DIFF
--- a/articles/azure-monitor/vm/vminsights-dependency-agent.md
+++ b/articles/azure-monitor/vm/vminsights-dependency-agent.md
@@ -19,7 +19,7 @@ Dependency Agent collects data about processes running on the virtual machine an
 
 - Azure Monitor agent must be installed on the same machine.
 - Requires a connection from the virtual machine to the address 169.254.169.254. This address identifies the Azure metadata service endpoint. 
-- Currently supports the same [Windows versions that Azure Monitor Agent supports](../agents/azure-monitor-agent-supported-operating-systems.md) up to Windows Server 2019, except Windows Server 2008 SP2 and Azure Stack HCI. For Linux, see [Dependency Agent Linux support](#dependency-agent-linux-support).
+- Currently supports the same [Windows versions that Azure Monitor Agent supports](../agents/azure-monitor-agent-supported-operating-systems.md) up to Windows Server 2022, except Windows Server 2008 SP2 and Azure Stack HCI. For Linux, see [Dependency Agent Linux support](#dependency-agent-linux-support).
 
 ## Linux considerations
 


### PR DESCRIPTION
Dependency Agent supports Windows Server 2022 per https://learn.microsoft.com/en-us/azure/virtual-machines/extensions/agent-dependency-windows