### PR TITLE
Clarify OpenTelemetry vs. Application Insights SDK feature gaps and advantages

### DIFF
--- a/articles/azure-monitor/app/opentelemetry-help-support-feedback.md
+++ b/articles/azure-monitor/app/opentelemetry-help-support-feedback.md
@@ -76,11 +76,11 @@ Check out our enablement docs for [.NET, Java, JavaScript (Node.js), and Python]
 
 We recommend using the Azure Monitor OpenTelemetry Distro for new projects when [its capabilities](#whats-the-current-release-state-of-features-within-the-azure-monitor-opentelemetry-distro) align with your monitoring needs. OpenTelemetry is an industry-standard framework that enhances cross-platform observability and provides a standardized approach to telemetry collection.
 
-However, the Application Insights SDKs still provide certain capabilities that are not yet fully automated in OpenTelemetry, including:
+However, the Application Insights SDKs still provide certain capabilities that aren't yet fully automated in OpenTelemetry, including:
 
 - Automatic dependency tracking – OpenTelemetry supports dependency tracking, but some dependencies require additional configuration compared to the automatic tracking available in Application Insights SDKs.
-- Custom telemetry types (e.g., `AvailabilityTelemetry`, `PageViewTelemetry`) – OpenTelemetry does not have direct equivalents; similar functionality can be implemented via manual instrumentation.
-- Telemetry processors and initializers – OpenTelemetry has processors and span processors, but they do not fully replace Application Insights Telemetry Processors and Initializers in all scenarios.
+- Custom telemetry types, such as `AvailabilityTelemetry` and `PageViewTelemetry` – OpenTelemetry doesn't have direct equivalents. Similar functionality can be implemented via manual instrumentation.
+- Telemetry processors and initializers – OpenTelemetry has processors and span processors, but they don't fully replace Application Insights Telemetry Processors and Initializers in all scenarios.
 - Extended metrics collection – While OpenTelemetry has a strong metrics system, some built-in metrics from Application Insights SDKs require manual setup in OpenTelemetry.
 
 OpenTelemetry also provides advantages over the Application Insights SDKs, including:
@@ -88,9 +88,9 @@ OpenTelemetry also provides advantages over the Application Insights SDKs, inclu
 - Better standardization across platforms
 - A wider ecosystem of instrumentation libraries
 - Greater flexibility in data collection and processing
-- Improved vendor neutrality (though Azure Monitor OpenTelemetry Distro is still optimized for Azure)
+- Improved vendor neutrality, though Azure Monitor OpenTelemetry Distro is still optimized for Azure.
 
-Azure Monitor's OpenTelemetry integration is continuously evolving, and Microsoft continues to enhance its capabilities. If you are considering a transition, carefully evaluate whether OpenTelemetry currently meets your observability requirements or if the Application Insights SDK remains the better fit for your needs.
+Azure Monitor's OpenTelemetry integration is continuously evolving, and Microsoft continues to enhance its capabilities. If you're considering a transition, carefully evaluate whether OpenTelemetry currently meets your observability requirements or if the Application Insights SDK remains the better fit for your needs.
 
 ### When should I use the Azure Monitor OpenTelemetry exporter?
 
@@ -484,3 +484,4 @@ To provide feedback:
 - Tell Microsoft about yourself by joining the [OpenTelemetry Early Adopter Community](https://aka.ms/AzMonOTel/).
 - Engage with other Azure Monitor users in the [Microsoft Tech Community](https://techcommunity.microsoft.com/t5/azure-monitor/bd-p/AzureMonitor).
 - Make a feature request at the [Azure Feedback Forum](https://feedback.azure.com/d365community/forum/3887dc70-2025-ec11-b6e6-000d3a4f09d0).
+ 

--- a/articles/azure-monitor/app/opentelemetry-help-support-feedback.md
+++ b/articles/azure-monitor/app/opentelemetry-help-support-feedback.md
@@ -74,9 +74,23 @@ Check out our enablement docs for [.NET, Java, JavaScript (Node.js), and Python]
 
 ### Should I use OpenTelemetry or the Application Insights SDK?
 
-We recommend using the OpenTelemetry Distro unless you require a [feature that is only available with formal support in the Application Insights SDK](#whats-the-current-release-state-of-features-within-the-azure-monitor-opentelemetry-distro).
+We recommend using the Azure Monitor OpenTelemetry Distro for new projects when [its capabilities](#whats-the-current-release-state-of-features-within-the-azure-monitor-opentelemetry-distro) align with your monitoring needs. OpenTelemetry is an industry-standard framework that enhances cross-platform observability and provides a standardized approach to telemetry collection.
 
-Adopting OpenTelemetry now prevents having to migrate at a later date.
+However, the Application Insights SDKs still provide certain capabilities that are not yet fully automated in OpenTelemetry, including:
+
+- Automatic dependency tracking – OpenTelemetry supports dependency tracking, but some dependencies require additional configuration compared to the automatic tracking available in Application Insights SDKs.
+- Custom telemetry types (e.g., `AvailabilityTelemetry`, `PageViewTelemetry`) – OpenTelemetry does not have direct equivalents; similar functionality can be implemented via manual instrumentation.
+- Telemetry processors and initializers – OpenTelemetry has processors and span processors, but they do not fully replace Application Insights Telemetry Processors and Initializers in all scenarios.
+- Extended metrics collection – While OpenTelemetry has a strong metrics system, some built-in metrics from Application Insights SDKs require manual setup in OpenTelemetry.
+
+OpenTelemetry also provides advantages over the Application Insights SDKs, including:
+
+- Better standardization across platforms
+- A wider ecosystem of instrumentation libraries
+- Greater flexibility in data collection and processing
+- Improved vendor neutrality (though Azure Monitor OpenTelemetry Distro is still optimized for Azure)
+
+Azure Monitor's OpenTelemetry integration is continuously evolving, and Microsoft continues to enhance its capabilities. If you are considering a transition, carefully evaluate whether OpenTelemetry currently meets your observability requirements or if the Application Insights SDK remains the better fit for your needs.
 
 ### When should I use the Azure Monitor OpenTelemetry exporter?
 


### PR DESCRIPTION
The current documentation is a bit misleading as it implies that the Azure Monitor OpenTelemetry Distro is the default recommended choice without fully addressing the feature gaps compared to the Application Insights SDKs.

This PR improves the guidance by:

- Clarifying missing automation in OpenTelemetry, such as dependency tracking and telemetry processors, which require additional configuration
- Highlighting OpenTelemetry’s advantages while ensuring a fair comparison
- Correcting misleading phrasing that suggests full feature parity between OpenTelemetry and Application Insights
- Providing a more balanced recommendation to help users make an informed decision

The revised text ensures transparency about what requires manual instrumentation in OpenTelemetry and highlights areas where the Application Insights SDK may still be a better fit. It also reinforces that Azure Monitor's OpenTelemetry integration is evolving while maintaining an objective and fact-based approach.

This clarification will help users accurately assess whether OpenTelemetry currently meets their observability requirements or if the Application Insights SDK remains the better choice for their needs.