### PR TITLE
Adding clarity for classic App Insights SDK API instructions

### DIFF
--- a/articles/azure-monitor/app/azure-ad-authentication.md
+++ b/articles/azure-monitor/app/azure-ad-authentication.md
@@ -116,7 +116,7 @@ Use the `APPLICATIONINSIGHTS_AUTHENTICATION_STRING` environment variable to let 
 |-------------------------------------------|------------------------------------------------------------------------|
 | APPLICATIONINSIGHTS_AUTHENTICATION_STRING | `Authorization=AAD;ClientId={Client id of the User-Assigned Identity}` |
 
-#### Manual configuration
+#### Classic API
 
 The following example shows how to configure `TelemetryConfiguration` by using .NET Core:
 
@@ -204,7 +204,7 @@ Use the `APPLICATIONINSIGHTS_AUTHENTICATION_STRING` environment variable to let 
 |-------------------------------------------|------------------------------------------------------------------------|
 | APPLICATIONINSIGHTS_AUTHENTICATION_STRING | `Authorization=AAD;ClientId={Client id of the User-Assigned Identity}` |
 
-#### Manual configuration
+#### Classic API
 
 The following example shows how to manually create and configure `TelemetryConfiguration` by using .NET:
 


### PR DESCRIPTION
This commit added some changes that add confusion for customers using the classic API.
https://github.com/MicrosoftDocs/azure-monitor-docs/commit/e8718f87a4090eea871a96ad076e48a226c7e3f4

One of my customers got confused because they're using the classic API in their code and was not sure which steps to follow. This is how I'm proposing to add some clarity but feel to format the article how you think is better. We just need to make sure that customers still using the classic API know which steps to follow to add Entra ID authentication.