### PR TITLE
Fix PodMonitor sample

### DIFF
--- a/articles/azure-monitor/containers/prometheus-metrics-scrape-crd.md
+++ b/articles/azure-monitor/containers/prometheus-metrics-scrape-crd.md
@@ -47,9 +47,9 @@ spec:
         operator: In
         values: [app-frontend, app-backend]
 
-    # [Optional] Filter by pod namespace
-    namespaceSelector:
-      matchNames: [app-frontend, app-backend]
+  # [Optional] Filter by pod namespace
+  namespaceSelector:
+    matchNames: [app-frontend, app-backend]
 
   # [Optional] Labels on the pod with these keys will be added as labels to each metric scraped
   podTargetLabels: [app, region, environment]


### PR DESCRIPTION
Based on https://github.com/Azure/prometheus-collector/blob/main/otelcollector/deploy/addon-chart/azure-monitor-metrics-addon/templates/ama-metrics-podmonitor-crd.yaml, `namespaceSelector` is under `spec`, not `spec.selector`.

Error seen currently:
```
Error from server (BadRequest): error when creating "/home/jrb/dev/Rollout/Charts/Rollout/templates/pod-monitor.yaml": PodMonitor in version "v1" cannot be handled as a PodMonitor: strict decoding error: unknown field "spec.selector.namespaceSelector"
```
