### PR TITLE
Update vminsights-enable.md

### DIFF
--- a/articles/azure-monitor/vm/vminsights-enable.md
+++ b/articles/azure-monitor/vm/vminsights-enable.md
@@ -37,7 +37,10 @@ When you enable VM Insights for a machine, the following agents are installed.
 
 The only configuration in a VM insights DCR is the Log Analytics workspace and whether or not to collect processes and dependencies data. Instead of creating a separate DCR for each machine, you should use a single DCR for each Log Analytics workspace you use for VM insights and associate that DCR with multiple machines. You may want to create separate DCRs if you want to collect processes and dependencies from some machines but not from others. 
 
-You shouldn't modify the VM insights DCR. If you need to collect additional data from the monitored machines, such as event logs and security logs, create additional DCRs and associate them with the same machines. You can get guidance for creating these DCRs from [Collect data with Azure Monitor Agent](../vm/data-collection.md).
+
+> [!NOTE]
+> You shouldn't modify the VM insights DCR. If you need to collect additional data from the monitored machines, such as event logs and security logs, create additional DCRs and associate them with the same machines. You can get guidance for creating these DCRs from [Collect data with Azure Monitor Agent](../vm/data-collection.md).
+
 
 :::image type="content" source="media/vminsights-enable-portal/vminsights-dcr.png" lightbox="media/vminsights-enable-portal/vminsights-dcr.png" alt-text="Diagram showing the operation of VM insights DCR compared to other DCRs associated with the same agents.":::
 


### PR DESCRIPTION
Highlighted paragraph indicating that the DCR generated for VM Insights should not be modified. For some reason, this information is being overlooked. This should resolve the issue and improve the readability of the document.