### PR TITLE
Query filter correction.md

### DIFF
--- a/articles/azure-monitor/containers/container-insights-high-scale.md
+++ b/articles/azure-monitor/containers/container-insights-high-scale.md
@@ -26,7 +26,7 @@ High scale logs collection is suited for environments sending more than 2,000 lo
 
 ```kusto
 ContainerLogV2 
-| where _ResourceId = "<cluster-resource-id>" 
+| where _ResourceId =~ "<cluster-resource-id>" 
 | summarize count() by bin(TimeGenerated, 1s), Computer 
 | render timechart 
 ```
@@ -35,7 +35,7 @@ ContainerLogV2
 
 ```kusto
  ContainerLogV2 
-| where _ResourceId = "<cluster-resource-id>"
+| where _ResourceId =~ "<cluster-resource-id>"
 | summarize BillableDataMB = sum(_BilledSize)/1024/1024 by bin(TimeGenerated, 1s), Computer 
 | render timechart 
 ```


### PR DESCRIPTION
Using the current query information:
ContainerLogV2 
| where _ResourceId = "<cluster-resource-id>" 

Using only "=" cause an error.
![image](https://github.com/user-attachments/assets/77ac3859-efe6-4787-87dd-a7de05dd1a22)
