### PR TITLE
Add additional benefit to migrating to new ingestion API

### DIFF
--- a/articles/azure-monitor/logs/custom-logs-migrate.md
+++ b/articles/azure-monitor/logs/custom-logs-migrate.md
@@ -21,7 +21,7 @@ The Log Ingestion API provides the following advantages over the Data Collector 
 - Supports [transformations](../essentials/data-collection-transformations.md), which enable you to modify the data before it's ingested into the destination table, including filtering and data manipulation.
 - Lets you send data to multiple destinations.  
 - Enables you to manage the destination table schema, including column names, and whether to add new columns to the destination table when the source data schema changes.
-- Granular role-based access controls (RBAC) limit access to ingest data by data collection rule and identity.
+- Supports role-based access controls (RBAC) to restrict data ingestion by data collection rule and identity
   
 ## Prerequisites
 

--- a/articles/azure-monitor/logs/custom-logs-migrate.md
+++ b/articles/azure-monitor/logs/custom-logs-migrate.md
@@ -21,6 +21,8 @@ The Log Ingestion API provides the following advantages over the Data Collector 
 - Supports [transformations](../essentials/data-collection-transformations.md), which enable you to modify the data before it's ingested into the destination table, including filtering and data manipulation.
 - Lets you send data to multiple destinations.  
 - Enables you to manage the destination table schema, including column names, and whether to add new columns to the destination table when the source data schema changes.
+- Granular role-based access controls (RBAC) limit access to ingest data by data collection rule and identity.
+  
 ## Prerequisites
 
 The migration procedure described in this article assumes you have:

--- a/articles/azure-monitor/logs/custom-logs-migrate.md
+++ b/articles/azure-monitor/logs/custom-logs-migrate.md
@@ -21,7 +21,7 @@ The Log Ingestion API provides the following advantages over the Data Collector 
 - Supports [transformations](../essentials/data-collection-transformations.md), which enable you to modify the data before it's ingested into the destination table, including filtering and data manipulation.
 - Lets you send data to multiple destinations.  
 - Enables you to manage the destination table schema, including column names, and whether to add new columns to the destination table when the source data schema changes.
-- Supports role-based access controls (RBAC) to restrict data ingestion by data collection rule and identity
+- Supports role-based access controls (RBAC) to restrict data ingestion by data collection rule and identity.
   
 ## Prerequisites
 


### PR DESCRIPTION
The old API used a primary or secondary key to secure ingestion.  These keys were used by all data sources to send data and could be used to send data to any table the API could access.  Rotating the key required all data sources to be updated with the new key.

The new API uses OAuth, and allows for identities to be granted access to specific data collection rules. This limiting what identities can ingest data to which tables and also limits key reuse by different systems.  When a key rotation is needed, only that identity is impacted.  This granularity is a benefit that should not be overlooked.