### PR TITLE
Fix image reference

### DIFF
--- a/articles/azure-monitor/alerts/alerts-payload-samples.md
+++ b/articles/azure-monitor/alerts/alerts-payload-samples.md
@@ -585,7 +585,7 @@ The following are sample metric alert payloads.
 
 ## Sample payloads for test actions
 
-![Screenshot showing available alert types when testing an Azure Action Group.](/articles/azure-monitor/alerts/media/alerts-payload-samples/test-action-group-alert-types.png)
+:::image type="content" source="media/alerts-payload-samples/test-action-group-alert-types.png" alt-text="Screenshot showing available alert types when testing an Azure Action Group.":::
 
 When configuring an **Azure Action Group** to route alert notifications (e.g., via webhook, Logic App, Azure Function, or Event Hub), it's important to verify that the receiving endpoint can handle the **Common Alert Schema** payload structure.
 


### PR DESCRIPTION
This PR introduces fix to an image reference in the section from PR #139. Additionally was used Learn Markdown instead of default one. 

![image](https://github.com/user-attachments/assets/644478ca-2466-47a7-b026-cb661cb56060)
 