### PR TITLE
Someone named an Azure Monitor table wrong, the solution is called Illumio, not Ilumio

### DIFF
--- a/articles/azure-monitor/reference/tables/ilumioinsights.md
+++ b/articles/azure-monitor/reference/tables/ilumioinsights.md
@@ -25,7 +25,7 @@ Illumio Insights data connector provides the capability to ingest audit and even
 |**Solutions**| SecurityInsights|
 |**Basic log**|Yes|
 |**Ingestion-time transformation**|No|
-|**Sample Queries**|[Yes](/azure/azure-monitor/reference/queries/Illumioinsights)|
+|**Sample Queries**|[Yes](/azure/azure-monitor/reference/queries/ilumioinsights)|
 
 
 


### PR DESCRIPTION
These docs are fine, and they should NOT be changed, UNLESS the table name is ALSO changed.

I am only creating this pull request because who created this Azure Monitor table might not know there is a spelling mistake.

The Sentinel solution in content hub has the correct name, Illumio, but the Azure Monitor table has the wrong name, Ilumio.