### PR TITLE
Update Prometheus docs for duplicate timeseries behavior

### DIFF
--- a/articles/azure-monitor/metrics/includes/prometheus-duplicate-timeseries.md
+++ b/articles/azure-monitor/metrics/includes/prometheus-duplicate-timeseries.md
@@ -1,0 +1,12 @@
+---
+ms.topic: include
+ms.date: 2025/07/25
+---
+
+## Avoiding duplicate time series
+
+Prometheus [does not support duplicate time series](https://promlabs.com/blog/2022/12/15/understanding-duplicate-samples-and-out-of-order-timestamp-errors-in-prometheus). Azure Managed Prometheus surfaces these to users as 422 errors rather than silently drop duplicate time series. Users encountering these errors should take action to avoid duplication of time series. 
+
+For example, if a user uses the same "cluster" label value for two different clusters stored in different resource groups but ingesting to the same AMW, they should rename one of these labels for uniqueness. This error will only arise in edge-cases where the timestamp and values are identical across both clusters in this scenario.
+
+This can be fixed by adding a unique identifier label, reinstrumenting an existing label that was intended to be unique, or using [relabel_configs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config) to inject or modify labels at scrape time.

--- a/articles/azure-monitor/metrics/prometheus-api-promql.md
+++ b/articles/azure-monitor/metrics/prometheus-api-promql.md
@@ -227,6 +227,8 @@ For more information on Prometheus metrics limits, see [Prometheus metrics](../f
 
 [!INCLUDE [prometheus-case-sensitivity.md](includes/prometheus-case-sensitivity.md)]
 
+[!INCLUDE [duplicate timeseries](includes/prometheus-duplicate-timeseries.md)]
+
 ## Frequently asked questions
 
 This section provides answers to common questions.

--- a/articles/azure-monitor/metrics/prometheus-metrics-overview.md
+++ b/articles/azure-monitor/metrics/prometheus-metrics-overview.md
@@ -127,6 +127,8 @@ The following limitations apply to Azure Monitor managed service for Prometheus:
 
 ## Metric names, label names & label values
 
+Metrics scraping currently has the limitations in the following table:
+
 | Property | Limit |
 |:---|:---|
 | Label name length | Less than or equal to 511 characters. When this limit is exceeded for any time-series in a job, the entire scrape job fails, and metrics get dropped from that job before ingestion. You can see up=0 for that job and also target Ux shows the reason for up=0. |

--- a/articles/azure-monitor/metrics/prometheus-metrics-overview.md
+++ b/articles/azure-monitor/metrics/prometheus-metrics-overview.md
@@ -123,9 +123,9 @@ The following limitations apply to Azure Monitor managed service for Prometheus:
 
 [!INCLUDE [case sensitivity](includes/prometheus-case-sensitivity.md)]
 
-## Metric names, label names & label values
+[!INCLUDE [duplicate timeseries](includes/prometheus-duplicate-timeseries.md)]
 
-Metrics scraping currently has the limitations in the following table:
+## Metric names, label names & label values
 
 | Property | Limit |
 |:---|:---|


### PR DESCRIPTION
This update adds context for users encountering 422 errors in some scenarios to debug by ensuring uniqueness for their identifier labels