### PR TITLE
Update customer-managed-keys.md - CapacityReservationLevel error

### DIFF
--- a/articles/azure-monitor/logs/customer-managed-keys.md
+++ b/articles/azure-monitor/logs/customer-managed-keys.md
@@ -167,6 +167,7 @@ This step updates dedicated cluster storage with the key and version to use for 
 >[!IMPORTANT]
 >- Key rotation can be automatic or per explicit key version, see [Key rotation](#key-rotation) to determine suitable approach before updating the key identifier details in cluster.
 >- Cluster update should not include both identity and key identifier details in the same operation. If you need to update both, the update should be in two consecutive operations.
+>- If you're only enabling or changing CMK, use the REST API instead of CLI to avoid capacity reservation errors due to CLI's stateless behaviour.
 
 :::image type="content" source="media/customer-managed-keys/key-identifier-8bit.png" lightbox="media/customer-managed-keys/key-identifier-8bit.png" alt-text="Screenshot of Grant Key Vault permissions.":::
 

--- a/articles/azure-monitor/logs/customer-managed-keys.md
+++ b/articles/azure-monitor/logs/customer-managed-keys.md
@@ -167,7 +167,7 @@ This step updates dedicated cluster storage with the key and version to use for 
 >[!IMPORTANT]
 >- Key rotation can be automatic or per explicit key version, see [Key rotation](#key-rotation) to determine suitable approach before updating the key identifier details in cluster.
 >- Cluster update should not include both identity and key identifier details in the same operation. If you need to update both, the update should be in two consecutive operations.
->- If you're only enabling or changing CMK, use the REST API instead of CLI to avoid capacity reservation errors due to CLI's stateless behaviour.
+>- If you're only enabling or changing CMK, use the REST API instead of the CLI. The cluster update CLI sends an update to capacity even when that property isn't used in the command, triggering thresholds for 30 day change or 500GB minimum.
 
 :::image type="content" source="media/customer-managed-keys/key-identifier-8bit.png" lightbox="media/customer-managed-keys/key-identifier-8bit.png" alt-text="Screenshot of Grant Key Vault permissions.":::
 


### PR DESCRIPTION
Customer receive error when trying to enable CMK via CLI:
Cx gets error for capacity reservation since he is not defining the capacity in the command itself.
This issue arises due to a limitation with the CLI method being stateless, which unfortunately doesn't retain the required capacity information during the process.

even though customer only wants to edit only CMK

 (InvalidInput) CapacityReservationLevel must be an allowed value: [GB500,T1,T2,T5]. Operation Id: 'xxxxxxxxxxxxxxxxxxxxxxxxx' Code: InvalidInput Message: CapacityReservationLevel must be an allowed value: [GB500,T1,T2,T5]. Operation Id: 'xxxxxxxxxxxxxxxxxxxxxxxxxxxx' Target: sku.capacity.~~
 
 
<img width="801" height="87" alt="image" src="https://github.com/user-attachments/assets/089bceaf-7422-413b-89ea-98657b12c17e" />


<img width="1022" height="492" alt="image" src="https://github.com/user-attachments/assets/208cabf9-f5bf-48e6-9df0-ced17ce5df84" />

**Removing the second json regarding Capacity solves the issue when doing via API, therefore only sending first json regarding enabling CMK

we need this to be a disclaimer that is updated to make it clear so it helped customers** 