### PR TITLE
Update limitations for VM insights

### DIFF
--- a/articles/azure-monitor/vm/vminsights-overview.md
+++ b/articles/azure-monitor/vm/vminsights-overview.md
@@ -52,6 +52,7 @@ VM insights supports the following operating systems:
 
 - VM insights collects a predefined set of metrics from the VM client and doesn't collect any event data. You can use the Azure portal to [create data collection rules](../vm/data-collection.md) to collect events and additional performance counters using the same Azure Monitor agent used by VM insights.
 - VM insights doesn't support sending data to multiple Log Analytics workspaces (multi-homing).
+- VM insights doesn't support any sampling frequency other than every 60 seconds for performance counters in the Microsoft-InsightsMetrics stream.
 
 ## Diagnostic and usage data
 


### PR DESCRIPTION
Adding limitation for not being able to alter performance collection to anything other than every 60 seconds. If you try to modify this you receive this error message:

Error Message:
"message":"Sampling frequency must be equal to 60 seconds for counters collected with Microsoft-InsightsMetrics stream."

- Perhaps we can also add this scenario error message in the troubleshooting doc (https://learn.microsoft.com/en-us/azure/azure-monitor/vm/vminsights-troubleshoot) as well to explain that what a customer is seeing is expected if they try to change this interval?