### PR TITLE
azure-monitor-agent-windows-client.md - Update authentication header in disassociate DCR script

### DIFF
--- a/articles/azure-monitor/agents/azure-monitor-agent-windows-client.md
+++ b/articles/azure-monitor/agents/azure-monitor-agent-windows-client.md
@@ -485,7 +485,7 @@ $auth = Get-AzAccessToken
 
 $AuthenticationHeader = @{
     "Content-Type" = "application/json"
-    "Authorization" = "Bearer " + $auth.Token
+    "Authorization" = "Bearer " + $(ConvertFrom-SecureString $auth.Token -AsPlainText)
 }
 
 #Get the monitored object


### PR DESCRIPTION
- Added support for the latest behaviour of Get-AzAccessToken, which now returns the token as a securestring, to the Disassociate script as well

Follow on from #182 