### PR TITLE
ServerTelemetryChannel on non-Windows use default locations

### DIFF
--- a/articles/azure-monitor/app/dot-net.md
+++ b/articles/azure-monitor/app/dot-net.md
@@ -3057,7 +3057,7 @@ Here are the most commonly used settings for `ServerTelemetryChannel`:
 
 * `MaxTransmissionSenderCapacity`: The maximum number of `Transmission` instances that are sent to Application Insights at the same time. The default value is 10. This setting can be configured to a higher number, which we recommend when a huge volume of telemetry is generated. High volume typically occurs during load testing or when sampling is turned off.
 
-* `StorageFolder`: The folder that's used by the channel to store items to disk as needed. In Windows, either %LOCALAPPDATA% or %TEMP% is used if no other path is specified explicitly. In environments other than Windows, you must specify a valid location or telemetry isn't stored to local disk.
+* `StorageFolder`: The folder that's used by the channel to store items to disk as needed. In Windows, either %LOCALAPPDATA% or %TEMP% is used if no other path is specified explicitly. In environments other than Windows, by default the following locations are used (in order): %TMPDIR%, /var/tmp/ or /tmp/.
 
 #### Which channel should I use?
 


### PR DESCRIPTION
`ServerTelemetryChannel` now also supports default locations to store telemetry items. Added this to the documentation.

See also: https://github.com/microsoft/ApplicationInsights-dotnet/blob/98bc6c540e2dcccc78e4b356cd70e03d146a01ad/BASE/src/ServerTelemetryChannel/Implementation/ApplicationFolderProvider.cs#L90-L110