### PR TITLE
Update email subject example to use first alert target

### DIFF
--- a/articles/azure-monitor/alerts/alerts-customize-email-subject-how-to.md
+++ b/articles/azure-monitor/alerts/alerts-customize-email-subject-how-to.md
@@ -36,7 +36,7 @@ The format for extracting a dynamic value from the alert payload is: `${<path to
 
 This example creates an email subject containing the affected resource and whether it was fired or resolved. 
 
-- Value: "Alert ${data.essentials.monitorCondition} on ${data.essentials.alertTargetIDs}"
+- Value: "Alert ${data.essentials.monitorCondition} on ${data.essentials.alertTargetIDs[0]}"
 - Potential results:
   - Alert Fired on VM1.
   - Alert Resolved on VM1.


### PR DESCRIPTION
Updated the email subject example in the alert customization documentation to use the correct syntax for array fields in the common alert schema.  Replaced `${data.essentials.alertTargetIDs}` with `${data.essentials.alertTargetIDs[0]}`, since `alertTargetIDs` is an array and must be accessed with an index.