### PR TITLE
Clarify Linux Syslog DCR portal UX: unchecked facilities aren't collected even when a Minimum log level is shown

### DIFF
--- a/articles/azure-monitor/vm/data-collection-syslog.md
+++ b/articles/azure-monitor/vm/data-collection-syslog.md
@@ -24,6 +24,11 @@ Create the DCR using the process in [Collect data from virtual machine client wi
 
 [!INCLUDE [configure-syslog-ama](~/reusable-content/ce-skilling/azure/includes/azure-monitor/agents/configure-syslog-ama.md)]
 
+> [!IMPORTANT]
+> The **Linux Syslog** data source page in the Azure portal DCR editor is an authoring form, not a status view. Only the facilities whose **checkbox is selected** are written to the DCR and collected by Azure Monitor Agent. The **Minimum log level** value displayed next to an *unchecked* facility is a default placeholder rendered by the form; it isn't part of the saved configuration and doesn't indicate that the facility is being collected.
+>
+> To verify the configuration that's actually applied, open the DCR and select **Overview** > **JSON View**, or run `az monitor data-collection rule show --ids <dcr-id> --query "properties.dataSources.syslog"`. A facility is collected only if it appears in `properties.dataSources.syslog[*].facilityNames`.
+
 
 >[!Note]
 >When ingesting syslog data using a log forwarder, inconsistencies may arise between the TimeGenerated and EventTime fields.


### PR DESCRIPTION
## Summary

Customers and security auditors reviewing the **Data Sources → Linux Syslog** page of a Data Collection Rule in the Azure portal are repeatedly confused by the fact that facilities whose checkbox is **cleared** still display a value in the **Minimum log level** dropdown (for example `LOG_INFO` or `none`). They interpret this as "the facility is configured but at the wrong level" and raise it as a security/compliance finding, even though the DCR JSON and the Log Analytics `Syslog` table show the facility is not being collected.

This PR adds a short clarifying `IMPORTANT` note to `articles/azure-monitor/vm/data-collection-syslog.md` explaining that:

1. The Linux Syslog blade is an authoring form; only **checked** facilities are written to the DCR.
2. The Minimum log level shown next to an unchecked facility is a UI default, not saved state.
3. The authoritative configuration is the DCR JSON (`properties.dataSources.syslog[*].facilityNames` / `logLevels`), viewable in **DCR → Overview → JSON View** or via `az monitor data-collection rule show`.

## Customer impact

Real Azure support case: an enterprise security audit flagged a production DCR as misconfigured purely because of this UX, even though the DCR JSON and ingested data were correct. A note in the public doc would have avoided the escalation.
