### PR TITLE
Add note about query audit visibility in MSSP and delegated access scenarios

### DIFF
--- a/articles/azure-monitor/logs/api/cross-workspace-queries.md
+++ b/articles/azure-monitor/logs/api/cross-workspace-queries.md
@@ -22,6 +22,10 @@ For either implicit or explicit cross-workspace queries, you need to specify the
 > [!NOTE]
 > We strongly recommend identifying a workspace by its unique Workspace ID or Azure Resource ID because they remove ambiguity and are more performant.
 
+> [!IMPORTANT]
+> For Azure Lighthouse, MSSP, and other delegated-access scenarios, organizations should be aware that cross-workspace queries executed against a customer's Log Analytics workspace may generate query audit records when query auditing is enabled. These records can provide visibility into query activity, including details such as query text, caller identity, and referenced workspaces or resources. Service providers should consider query auditability when designing cross-workspace investigations, automation workflows, and shared query functions.
+
+
 ## Implicit cross workspace queries
 
 For implicit syntax, specify the workspaces that you want to include in your query scope. The API performs a single query over each application provided in your list. The syntax for a cross-workspace POST is:

--- a/articles/azure-monitor/logs/cross-workspace-query.md
+++ b/articles/azure-monitor/logs/cross-workspace-query.md
@@ -20,6 +20,7 @@ When you manage subscriptions in other Microsoft Entra tenants with [Azure Light
 
 > [!IMPORTANT]
 > If you're using a [workspace-based Application Insights resource](../app/create-workspace-resource.md), telemetry is stored in a Log Analytics workspace with all other log data. Use the `workspace()` expression to query data from applications in multiple workspaces. You don't need a cross-workspace query to query data from multiple applications in the same workspace.
+> For Azure Lighthouse, MSSP, and other delegated-access scenarios, organizations should be aware that cross-workspace queries executed against a customer's Log Analytics workspace may generate query audit records when query auditing is enabled. These records can provide visibility into query activity, including details such as query text, caller identity, and referenced workspaces or resources. Service providers should consider query auditability when designing cross-workspace investigations, automation workflows, and shared query functions.
 
 ## Permissions required
 


### PR DESCRIPTION
Add a documentation note highlighting that cross-workspace queries executed against a customer Log Analytics workspace may be recorded in query audit logs (for example, LAQueryLogs) when query auditing is enabled.

The intent is not to describe a security issue or vulnerability, but to clarify auditability and transparency considerations for Azure Lighthouse, MSSP, and other delegated-access scenarios. Customers with access to query audit records may have visibility into query activity performed against their workspaces, including query metadata depending on the execution path and audit configuration.

This is generally for MSSPs who use cross workspace query from theier Sentinel env to keep the Analytics/Hunting Queries (secret sauce) in their environment.