### PR TITLE
Document generative AI content telemetry

### DIFF
--- a/articles/azure-monitor/app/data-model-complete.md
+++ b/articles/azure-monitor/app/data-model-complete.md
@@ -33,6 +33,7 @@ The following types of telemetry are used to monitor the execution of your appli
 | [Dependency](#dependency-telemetry) | `dependencies` | `AppDependencies` | Tracks calls from your application to an external service or storage, such as a REST API or SQL database, and measures the duration and success of these calls. |
 | [Event](#event-telemetry) | `customEvents` | `AppEvents` | Typically used to capture user interactions and other significant occurrences within your application, such as button clicks or order checkouts, to analyze usage patterns. |
 | [Exception](#exception-telemetry) | `exceptions` | `AppExceptions` | Captures error information crucial for troubleshooting and understanding failures. |
+| [Generative AI content](#generative-ai-content-telemetry) | `genAIContent` | `AppGenAIContent` | Captures generative AI content from OpenTelemetry sources, including input and output messages, system instructions, and tool interactions. |
 | [Metric](#metric-telemetry) | `performanceCounters`<br><br>`customMetrics` | `AppPerformanceCounters`<br><br>`AppMetrics` | Performance counters provide numerical data about various aspects of application and system performance, such as CPU usage and memory consumption.<br><br>Additionally, custom metrics allow you to define and track specific measurements unique to your application, providing flexibility to monitor custom performance indicators. |
 | [Page view](#page-view-telemetry) | `pageViews` | `AppPageViews` | Tracks the pages viewed by users, providing insights into user navigation and engagement within your application. |
 | [Request](#request-telemetry) | `requests` | `AppRequests` | Logs requests received by your application, providing details such as operation ID, duration, and success or failure status. |
@@ -144,6 +145,14 @@ An exception telemetry item represents a handled or unhandled exception that occ
 | `details` | `Details` | Contains exception information such as the exception message and the call stack. |
 
 For a list of all available fields, see [AppExceptions](../reference/tables/appexceptions.md).
+
+## Generative AI content telemetry
+
+Generative AI content telemetry captures content from OpenTelemetry sources for generative AI applications and agents. It includes input and output messages, system instructions, tool definitions, tool call arguments, and tool call results.
+
+Application Insights uses this telemetry in the [Agents (Preview)](agents-view.md) view to help monitor agent behavior, token usage, tool calls, and related traces.
+
+For the complete Log Analytics schema, see [AppGenAIContent](../reference/tables/appgenaicontent.md).
 
 ## Metric telemetry
 


### PR DESCRIPTION
Added section on generative AI content telemetry, including its purpose and usage in Application Insights.

<img width="1077" height="750" alt="image" src="https://github.com/user-attachments/assets/84abadb3-acc2-4b85-8e8a-0c3bfba600f3" />

<img width="1172" height="297" alt="image" src="https://github.com/user-attachments/assets/1cc526f3-74fd-433f-b9fe-1b163c83e951" />


---
## Summary

- Add Generative AI content telemetry to the Application Insights telemetry type table.
- Document the table name mapping:
  - Application Insights: `genAIContent`
  - Log Analytics: `AppGenAIContent`
- Add a short section that links GenAI content telemetry to OpenTelemetry sources and the Application Insights Agents view.

## Why

The Azure Monitor Logs reference already documents `AppGenAIContent` as a table for generative AI content captured from OpenTelemetry sources, including input and output messages, system instructions, and tool interactions.

Application Insights also has the Agents (Preview) experience for monitoring AI agents, but the Application Insights telemetry data model page does not currently list the corresponding GenAI content telemetry table. This makes it difficult for users to understand the table-name mapping between Application Insights Logs and Log Analytics.

## Validation

Docs-only change.

Verified existing related documentation:

- `AppGenAIContent` table reference:
  https://learn.microsoft.com/azure/azure-monitor/reference/tables/appgenaicontent
- Application Insights Agents view:
  https://learn.microsoft.com/azure/azure-monitor/app/agents-view
- Application Insights telemetry data model:
  https://learn.microsoft.com/azure/azure-monitor/app/data-model-complete

## Reviewer note

Please confirm the Application Insights table name `genAIContent`. The Log Analytics table name `AppGenAIContent` is already documented in the Azure Monitor Logs reference.